### PR TITLE
should set colisionId when colisionId is less than zero

### DIFF
--- a/src/colisionDetector.js
+++ b/src/colisionDetector.js
@@ -94,7 +94,7 @@ export default class colisionDetector {
     if( isRemoveOnly ) return;
 
     let settingId;
-    if ((typeof item.colisionState.colisionId !== 'undefined') || (item.colisionState.colisionId < 0)) {
+    if ((typeof item.colisionState.colisionId !== 'undefined') && (item.colisionState.colisionId >= 0)) {
       settingId = item.colisionState.colisionId;
     } else {
       settingId = this._numberingColisionIdCounter++;

--- a/test/colisionDetector.test.js
+++ b/test/colisionDetector.test.js
@@ -169,6 +169,35 @@ describe('#updateTree', () => {
     expect(colisionDetector._linearQuaternaryTree[5].length).toEqual(0);
     expect(colisionDetector._linearQuaternaryTree[10].length).toEqual(1);
   });
+
+  it('should allocate colisionId when given items colisionId is less than zero', () => {
+    const item1 = {
+      position: [100, 100],
+      width: 30,
+      height: 30,
+      colisionState: {
+        colisionId: -1
+      }
+    }
+    const colisionDetector = new ColisionDetector(800, 800, 2);
+    colisionDetector.updateTree(item1);
+    console.log(item1);
+    expect(item1.colisionState.colisionId).not.toEqual(-1);
+  });
+
+  it('keep colisionId when given items colisionId is over than zero', () => {
+    const item1 = {
+      position: [100, 100],
+      width: 30,
+      height: 30,
+      colisionState: {
+        colisionId: 1
+      }
+    }
+    const colisionDetector = new ColisionDetector(800, 800, 2);
+    colisionDetector.updateTree(item1);
+    expect(item1.colisionState.colisionId).toEqual(1);
+  });
 });
 
 describe('#detect', () => {


### PR DESCRIPTION
The ColisionId was not automatically allocated.

### Expected Behavior
ColisionId is set by colision-detector when given item's colisionId is less than zero.

### Actual Behavior
ColisionId isnot set even if colisionId is less than zero.